### PR TITLE
add an analysis page with hospitalizations graph

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react": "^17.0.1",
     "react-calendar": "^3.4.0",
     "react-content-loader": "^6.0.1",
+    "react-datawrapper-chart": "^1.1.1",
     "react-dom": "^17.0.1",
     "react-feather": "^2.0.9",
     "react-helmet": "^6.1.0",

--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,7 @@ import {Route, Redirect, Switch, useLocation} from 'react-router-dom';
 const Home = lazy(() => retry(() => import('./components/Home')));
 const About = lazy(() => retry(() => import('./components/About')));
 const State = lazy(() => retry(() => import('./components/State')));
+const Analysis = lazy(() => retry(() => import('./components/Analysis')));
 const LanguageSwitcher = lazy(() =>
   retry(() => import('./components/LanguageSwitcher'))
 );
@@ -22,6 +23,12 @@ const App = () => {
       pageLink: '/',
       view: Home,
       displayName: 'Home',
+      showInNavbar: true,
+    },
+    {
+      pageLink: '/analysis',
+      view: Analysis,
+      displayName: 'Analysis',
       showInNavbar: true,
     },
     {

--- a/src/components/Analysis.js
+++ b/src/components/Analysis.js
@@ -1,0 +1,69 @@
+import {API_REFRESH_INTERVAL, DATA_API_ROOT} from '../constants';
+import useIsVisible from '../hooks/useIsVisible';
+import useStickySWR from '../hooks/useStickySWR';
+import {fetcher, retry} from '../utils/commonFunctions';
+import DWChart from 'react-datawrapper-chart';
+import {useRef, useState, lazy, Suspense} from 'react';
+import {Helmet} from 'react-helmet';
+import {useLocation} from 'react-router-dom';
+import {useWindowSize} from 'react-use';
+
+const Footer = lazy(() => retry(() => import('./Footer')));
+
+function Analysis() {
+  const [regionHighlighted, setRegionHighlighted] = useState({
+    stateCode: 'TT',
+    districtName: null,
+  });
+
+  const [date, setDate] = useState('');
+  const location = useLocation();
+
+  const {data} = useStickySWR(
+    `${DATA_API_ROOT}/data${date ? `-${date}` : ''}.min.json`,
+    fetcher,
+    {
+      revalidateOnMount: true,
+      refreshInterval: API_REFRESH_INTERVAL,
+    }
+  );
+
+  const homeRightElement = useRef();
+  const isVisible = useIsVisible(homeRightElement);
+  const {width} = useWindowSize();
+
+  return (
+    <>
+      <Helmet>
+        <title>Coronavirus Outbreak in India - covid19bharat.org</title>
+        <meta
+          name="title"
+          content="Coronavirus Outbreak in India: Latest Map and Case Count"
+        />
+      </Helmet>
+
+      <div className="Home" ref={homeRightElement}>
+          {(isVisible || location.hash) && (
+            <> 
+            
+              <div className='home-left'>
+                  <DWChart title="hospitalization-total" src="https://datawrapper.dwcdn.net/1s4oD/5/" />
+              </div>
+
+              <div className='home-right'>
+                  <DWChart title="hospitalization-total" src="https://datawrapper.dwcdn.net/h4L6F/5/" />
+              </div>
+            </>
+          )}
+        </div>
+
+      {isVisible && (
+        <Suspense fallback={<div />}>
+          <Footer />
+        </Suspense>
+      )}
+    </>
+  );
+}
+
+export default Analysis;

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -7,7 +7,7 @@ import {
 import locales from '../i18n/locales.json';
 
 import {useState, useCallback, useRef} from 'react';
-import {HelpCircle, Home, Moon, Sun} from 'react-feather';
+import {HelpCircle, Home, Moon, Sun, BarChart} from 'react-feather';
 import {useTranslation} from 'react-i18next';
 import {Link} from 'react-router-dom';
 import {useTransition, animated} from 'react-spring';
@@ -79,6 +79,11 @@ function Navbar({pages, showLanguageSwitcher, setShowLanguageSwitcher}) {
             <Link to="/">
               <span>
                 <Home {...activeNavIcon('/')} />
+              </span>
+            </Link>
+            <Link to="/analysis">
+              <span>
+                <BarChart {...activeNavIcon('/analysis')} />
               </span>
             </Link>
             <Link to="/about">

--- a/yarn.lock
+++ b/yarn.lock
@@ -10300,6 +10300,15 @@ prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
     object-assign "^4.1.1"
     react-is "^16.8.1"
 
+prop-types@^15.7.0:
+  version "15.8.0"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.0.tgz#d237e624c45a9846e469f5f31117f970017ff588"
+  integrity sha512-fDGekdaHh65eI3lMi5OnErU6a8Ighg2KjcjQxO7m8VHyWjcPyj5kiOgV1LQDOOOgVy3+5FgjXvdSSX7B8/5/4g==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.13.1"
+
 proxy-addr@~2.0.5:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.7.tgz#f19fe69ceab311eeb94b42e70e8c2070f9ba1025"
@@ -10496,6 +10505,13 @@ react-content-loader@^6.0.1:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/react-content-loader/-/react-content-loader-6.0.3.tgz#32e28ca7120e0a2552fc26655d0d4448cc1fc0c5"
   integrity sha512-CIRgTHze+ls+jGDIfCitw27YkW2XcaMpsYORTUdBxsMFiKuUYMnlvY76dZE4Lsaa9vFXVw+41ieBEK7SJt0nug==
+
+react-datawrapper-chart@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/react-datawrapper-chart/-/react-datawrapper-chart-1.1.1.tgz#b9e5bd856c375c45f870014ae4b123710a9553c7"
+  integrity sha512-Br3XrN2uND7SbXxGNHpp7kppIXG9JhvuC8u1ESFSOyGIjX3lhVDDNxvDp3a9DHTUxvKSzlS9j/KxCOKbwQrZ0w==
+  dependencies:
+    prop-types "^15.7.0"
 
 react-dev-utils@^11.0.3:
   version "11.0.4"


### PR DESCRIPTION
**Description of PR**

This PR adds an analysis page to the website, which currently has 2 graphs -- hospitalizations in the last 2 months, and hospitalizations overall. These graphs auto-update as new data is made available. Rest of the data flow and the interface of the website remains the same.

**Screenshots**

- Analysis tab Navigation 

<img width="316" alt="Screen Shot 2022-01-05 at 9 18 36 PM" src="https://user-images.githubusercontent.com/991913/148317609-036bf0bd-5651-44ee-8786-ad82f7c7f084.png">

- Analysis page
<img width="1676" alt="Screen Shot 2022-01-05 at 9 22 16 PM" src="https://user-images.githubusercontent.com/991913/148317941-f79c7d8e-1f98-461d-a69b-f6eb021d0360.png">

