### PR TITLE
update analyses on the analysis page

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -5656,3 +5656,8 @@ footer {
     transform: translate3d(0, 20px, 0);
   }
 }
+
+.analysis-chart {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}

--- a/src/components/Analysis.js
+++ b/src/components/Analysis.js
@@ -8,6 +8,7 @@ import {Helmet} from 'react-helmet';
 import {useLocation} from 'react-router-dom';
 
 const Footer = lazy(() => retry(() => import('./Footer')));
+const BannerAnalysis = lazy(() => retry(() => import('./BannerAnalysis')));
 
 function Analysis() {
   const location = useLocation();
@@ -25,23 +26,103 @@ function Analysis() {
         />
       </Helmet>
 
+      <BannerAnalysis />
+
       <div className="Home" ref={homeRightElement}>
         {(isVisible || location.hash) && (
           <>
             <div className="home-left">
               <DWChart
-                title="hospitalization-60days"
-                src="https://datawrapper.dwcdn.net/1s4oD/5/"
+                className="analysis-chart"
+                title="delhi-hospitalization"
+                src="https://datawrapper.dwcdn.net/kA9vI/1/"
+              />
+              <DWChart
+                className="analysis-chart"
+                title="delhi-containment-zones"
+                src="https://datawrapper.dwcdn.net/WgMQ1/1/"
               />
             </div>
             <div className="home-right">
               <DWChart
-                title="hospitalization-total"
-                src="https://datawrapper.dwcdn.net/h4L6F/5/"
+                className="analysis-chart"
+                title="delhi-hospitalization-status"
+                src="https://datawrapper.dwcdn.net/LJ10m/1/"
+              />
+              <DWChart
+                className="analysis-chart"
+                title="delhi-rtpcr"
+                src="https://datawrapper.dwcdn.net/NlrvU/1/"
               />
             </div>
           </>
         )}
+      </div>
+      <div className="Home" ref={homeRightElement}>
+        {(isVisible || location.hash) && (
+          <>
+            <div className="home-left">
+              <DWChart
+                className="analysis-chart"
+                title="goa-hospitalization"
+                src="https://datawrapper.dwcdn.net/g7XR5/1/"
+              />
+            </div>
+            <div className="home-right"></div>
+          </>
+        )}
+      </div>
+      <div className="Home" ref={homeRightElement}>
+        {(isVisible || location.hash) && (
+          <>
+            <div className="home-left">
+              <DWChart
+                className="analysis-chart"
+                title="haryana-homeisolation"
+                src="https://datawrapper.dwcdn.net/eVxp8/1/"
+              />
+            </div>
+            <div className="home-right">
+              <DWChart
+                className="analysis-chart"
+                title="haryana-gender-samples"
+                src="https://datawrapper.dwcdn.net/dlD0d/1/"
+              />
+            </div>
+          </>
+        )}
+      </div>
+      <div className="Home" ref={homeRightElement}>
+        {(isVisible || location.hash) && (
+          <>
+            <div className="home-left">
+              <DWChart
+                className="analysis-chart"
+                title="karnataka-gender"
+                src="https://datawrapper.dwcdn.net/CoA4j/1/"
+              />
+            </div>
+            <div className="home-right">
+              <DWChart
+                className="analysis-chart"
+                title="kerala-gender"
+                src="https://datawrapper.dwcdn.net/jbsvt/1/"
+              />
+            </div>
+            <DWChart
+              className="analysis-chart"
+              title="karnataka-gender"
+              src="https://datawrapper.dwcdn.net/DTh1J/1/"
+            />
+          </>
+        )}
+      </div>
+      <div className="Home">
+        <DWChart
+          className="analysis-chart"
+          title="kerala-gender"
+          src="https://datawrapper.dwcdn.net/0nd9j/1/"
+        />
       </div>
 
       {isVisible && (

--- a/src/components/BannerAnalysis.js
+++ b/src/components/BannerAnalysis.js
@@ -1,0 +1,27 @@
+import {InfoIcon, ArrowRightIcon} from '@primer/octicons-react';
+import {useTranslation} from 'react-i18next';
+
+function BannerAnalysis(props) {
+  const {t} = useTranslation();
+
+  return (
+    <div className="Banner fadeInDown" style={{animationDelay: '0.4s'}}>
+      <div className="wrapper">
+        <div className="alert-icon">
+          <InfoIcon size={16} />
+        </div>
+        <div className="content">
+          {'Data on the Analysis page has been sourced from: '}{' '}
+        </div>
+        <a href="https://ibm.biz/covid-data-india" rel="noreferrer">
+          {t('ibm.biz/covid-data-india')}
+          <div className="arrow-right-icon">
+            <ArrowRightIcon size={16} />
+          </div>
+        </a>
+      </div>
+    </div>
+  );
+}
+
+export default BannerAnalysis;


### PR DESCRIPTION
**Description of PR**

- Adds a banner on top of the analysis page linking back to the IBM data website. This banner is displayed only on the Analysis page and not on other pages. Please let me know if there are any objections to this.
- Adds multiple new analyses to show hospitalization, home isolation, age and gender-wise fatality numbers.

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [ ] Tested on phone

**Screenshots**

<img width="1680" alt="Screen Shot 2022-01-19 at 1 08 38 AM" src="https://user-images.githubusercontent.com/991913/150073859-32d8f3ad-9db0-45b6-be3d-153abe199cab.png">

<img width="1680" alt="Screen Shot 2022-01-19 at 1 08 59 AM" src="https://user-images.githubusercontent.com/991913/150073901-44a2d72d-bcb3-4469-839a-f6a223f99d64.png">

<img width="1680" alt="Screen Shot 2022-01-19 at 1 09 20 AM" src="https://user-images.githubusercontent.com/991913/150073936-fbc759eb-885d-49e0-8004-c692679c045c.png">

