### PR TITLE
add booster dose information to frontend

### DIFF
--- a/src/components/VaccinationHeader.js
+++ b/src/components/VaccinationHeader.js
@@ -117,29 +117,49 @@ function Level({data}) {
 
   const spring = useSpring({
     total: getStatistic(data, 'total', 'vaccinated'),
+    booster: getStatistic(data, 'total', 'precautionary'),
     // delta: getStatistic(data, 'delta', 'vaccinated'),
     config: SPRING_CONFIG_NUMBERS,
   });
 
   const statisticConfig = STATISTIC_CONFIGS.vaccinated;
+  const boosterConfig = STATISTIC_CONFIGS.precautionary;
 
   return (
-    <div
-      className="level-vaccinated fadeInUp"
-      style={{animationDelay: `${750 + 4 * 250}ms`}}
-    >
-      <ShieldCheckIcon />
-      <animated.div>
-        {spring.total.to((total) => formatNumber(total, 'long'))}
-      </animated.div>
-      {/* <animated.div>
-        {spring.delta.to(
-          (delta) =>
-            `(+ ${formatNumber(delta, 'long')})`
-        )}
-      </animated.div> */}
-      <div>{t(statisticConfig.displayName)}</div>
-    </div>
+    <>
+      <div
+        className="level-vaccinated fadeInUp"
+        style={{animationDelay: `${750 + 4 * 250}ms`}}
+      >
+        <ShieldCheckIcon />
+        <animated.div>
+          {spring.total.to((total) => formatNumber(total, 'long'))}
+        </animated.div>
+        {/* <animated.div>
+          {spring.delta.to(
+            (delta) =>
+              `(+ ${formatNumber(delta, 'long')})`
+          )}
+        </animated.div> */}
+        <div>{t(statisticConfig.displayName)}</div>
+      </div>
+      <div
+        className="level-vaccinated fadeInUp"
+        style={{animationDelay: `${750 + 4 * 250}ms`}}
+      >
+        <ShieldCheckIcon />
+        <animated.div>
+          {spring.booster.to((booster) => formatNumber(booster, 'long'))}
+        </animated.div>
+        {/* <animated.div>
+          {spring.delta.to(
+            (delta) =>
+              `(+ ${formatNumber(delta, 'long')})`
+          )}
+        </animated.div> */}
+        <div>{boosterConfig.displayName}</div>
+      </div>
+    </>
   );
 }
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -89,6 +89,14 @@ export const STATISTIC_CONFIGS = {
     hideZero: true,
     category: 'vaccinated',
   },
+  precautionary: {
+    displayName: 'precautionary doses administered',
+    color: '#fb5581',
+    format: 'short',
+    showDelta: true,
+    hideZero: true,
+    category: 'vaccinated',
+  },
   tpr: {
     displayName: 'test positivity ratio',
     format: '%',


### PR DESCRIPTION
**Description of PR**

Adds booster dose (precautionary doses) information to the frontend

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**

1. Home page table has "precautionary doses administered" column
<img width="1320" alt="Screen Shot 2022-01-23 at 1 03 55 PM" src="https://user-images.githubusercontent.com/991913/150691714-f375d442-180d-4a72-a226-c30bd216eca5.png">

2. Each state page has the state specific information too

<img width="652" alt="Screen Shot 2022-01-23 at 1 04 33 PM" src="https://user-images.githubusercontent.com/991913/150691732-9e573ada-4756-4a81-a6da-1da5037702a2.png">

