### PR TITLE
fix total vaccination count

### DIFF
--- a/src/components/VaccinationHeader.js
+++ b/src/components/VaccinationHeader.js
@@ -12,7 +12,7 @@ import {animated, useSpring, Globals} from 'react-spring';
 // It renders administered => administergba(255, 0, 0, 1)
 Globals.assign({colors: null});
 
-function ProgressBar({dose1, dose2}) {
+function ProgressBar({dose1, dose2, booster}) {
   const {t} = useTranslation();
   const [highlightedDose, setHighlightedDose] = useState(2);
   const isMounted = useRef(false);
@@ -20,9 +20,11 @@ function ProgressBar({dose1, dose2}) {
   const doseSpring = useSpring({
     dose1,
     dose2,
+    booster,
     from: {
       dose1: 0,
       dose2: 0,
+      booster: 0,
     },
     delay: isMounted.current ? 0 : 2000,
   });
@@ -108,6 +110,34 @@ function ProgressBar({dose1, dose2}) {
           </div>
         </div>
       )}
+      {booster > 0 && (
+        <div
+          className={classnames('legend', {
+            highlighted: highlightedDose === 2,
+          })}
+        >
+          <animated.div
+            className="arrow"
+            style={{
+              marginLeft: doseSpring.booster.to((n) => `calc(${n}% - 0.3ch)`),
+            }}
+          >
+            |
+          </animated.div>
+          <div className="label-wrapper">
+            <animated.div
+              style={{
+                width: doseSpring.booster.to((n) => `calc(${n}% - 4rem)`),
+              }}
+            />
+            <animated.div className="label">
+              {doseSpring.booster.to(
+                (n) => `${t('Precautionary dose')} (${formatNumber(n, '%')})`
+              )}
+            </animated.div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }
@@ -117,13 +147,11 @@ function Level({data}) {
 
   const spring = useSpring({
     total: getStatistic(data, 'total', 'vaccinated'),
-    booster: getStatistic(data, 'total', 'precautionary'),
     // delta: getStatistic(data, 'delta', 'vaccinated'),
     config: SPRING_CONFIG_NUMBERS,
   });
 
   const statisticConfig = STATISTIC_CONFIGS.vaccinated;
-  const boosterConfig = STATISTIC_CONFIGS.precautionary;
 
   return (
     <>
@@ -143,22 +171,6 @@ function Level({data}) {
         </animated.div> */}
         <div>{t(statisticConfig.displayName)}</div>
       </div>
-      <div
-        className="level-vaccinated fadeInUp"
-        style={{animationDelay: `${750 + 4 * 250}ms`}}
-      >
-        <ShieldCheckIcon />
-        <animated.div>
-          {spring.booster.to((booster) => formatNumber(booster, 'long'))}
-        </animated.div>
-        {/* <animated.div>
-          {spring.delta.to(
-            (delta) =>
-              `(+ ${formatNumber(delta, 'long')})`
-          )}
-        </animated.div> */}
-        <div>{boosterConfig.displayName}</div>
-      </div>
     </>
   );
 }
@@ -170,11 +182,14 @@ function VaccinationHeader({data}) {
   const dose2 = getStatistic(data, 'total', 'vaccinated2', {
     normalizedByPopulationPer: 'hundred',
   });
+  const booster = getStatistic(data, 'total', 'precautionary', {
+    normalizedByPopulationPer: 'hundred',
+  });
 
   return (
     <div className="VaccinationHeader">
       <Level {...{data}} />
-      <ProgressBar {...{dose1, dose2}} />
+      <ProgressBar {...{dose1, dose2, booster}} />
     </div>
   );
 }

--- a/src/utils/commonFunctions.js
+++ b/src/utils/commonFunctions.js
@@ -193,7 +193,8 @@ export const getStatistic = (
   } else if (statistic === 'vaccinated') {
     const dose1 = data?.[type]?.vaccinated1 || 0;
     const dose2 = data?.[type]?.vaccinated2 || 0;
-    val = dose1 + dose2;
+    const booster = data?.[type]?.precautionary || 0;
+    val = dose1 + dose2 + booster;
   } else if (statistic === 'tpr') {
     const confirmed = data?.[type]?.confirmed || 0;
     const tested = data?.[type]?.tested || 0;


### PR DESCRIPTION
**Description of PR**

- Fixes `total vaccination count = vaccination_1 + vaccination_2 + booster dose`
- Remove count of precautionary vaccination from header and merge into the progress bar

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**

<img width="677" alt="Screen Shot 2022-01-23 at 2 49 06 PM" src="https://user-images.githubusercontent.com/991913/150695502-2e9264bd-e19c-49f7-a638-849cba569fd6.png">

